### PR TITLE
Let the type of map and co be specified by a parameter

### DIFF
--- a/src/ReactiveBasics.jl
+++ b/src/ReactiveBasics.jl
@@ -4,7 +4,7 @@ using DocStringExtensions
 
 export Signal, value, foldp, subscribe!, flatmap, flatten, bind!, droprepeats, previous, sampleon, preserve
 
-# This API mainly follows that of Reactive.jl. 
+# This API mainly follows that of Reactive.jl.
 
 # The algorithms for were derived from the Swift Interstellar package
 # https://github.com/JensRavens/Interstellar/blob/master/Sources/Signal.swift
@@ -17,7 +17,7 @@ A `Signal` is value that will contain a value in the future.
 The value of the Signal can change at any time.
 
 Use `map` to derive new Signals, `subscribe!` to subscribe to updates of a Signal,
-and `push!` to update the current value of a Signal. 
+and `push!` to update the current value of a Signal.
 `value` returns the current value of a Signal.
 
 ```julia
@@ -87,7 +87,7 @@ end
 """
 $(SIGNATURES)
 
-Transform the Signal into another Signal using a function. It's like `map`, 
+Transform the Signal into another Signal using a function. It's like `map`,
 but it's meant for functions that return `Signal`s.
 """
 function flatmap(f, input::Signal)
@@ -98,7 +98,7 @@ function flatmap(f, input::Signal)
         subscribe!(innersig) do v
             push!(signal, v)
         end
-    end      
+    end
     signal
 end
 
@@ -125,7 +125,7 @@ end
 """
 $(SIGNATURES)
 
-Unsubscribe to the changes of this Signal. 
+Unsubscribe to the changes of this Signal.
 """
 function unsubscribe!(f, u::Signal)
     u.callbacks = filter(a -> a != f, u.callbacks)
@@ -137,7 +137,7 @@ $(SIGNATURES)
 
 Zip (combine) Signals into the current Signal. The value of the Signal is a
 Tuple of the values of the contained Signals.
-    
+
     signal = zip(Signal("Hello"), Signal("World"))
     value(signal)    # ("Hello", "World")
 """
@@ -163,7 +163,7 @@ end
 $(SIGNATURES)
 
 Fold/map over past values. The first argument to the function `f`
-is an accumulated value that the function can operate over, and the 
+is an accumulated value that the function can operate over, and the
 second is the current value coming in. `v0` is the initial value of
 the accumulated value.
 
@@ -175,7 +175,11 @@ the accumulated value.
 """
 function foldp(f, v0, us::Signal...)
     v0r = Ref(v0)
-    map((x...) -> v0r[] = f(v0r[], x...), us...)
+    if isa(v0r, Base.RefArray)
+        map((x...) -> v0r.x[:] = f(v0r.x, x...), us...)
+    else
+        map((x...) -> v0r[] = f(v0r.x, x...), us...)
+    end
 end
 
 """
@@ -205,7 +209,7 @@ end
 $(SIGNATURES)
 
 Flatten a Signal of Signals into a Signal which holds the
-value of the current Signal. 
+value of the current Signal.
 """
 function flatten(input::Signal)
     sigref = Ref(input.value)
@@ -214,11 +218,15 @@ function flatten(input::Signal)
     subscribe!(updater, input.value)
     subscribe!(input) do u
         push!(signal, u.value)
-        unsubscribe!(updater, sigref[])
+        unsubscribe!(updater, sigref.x)
         subscribe!(updater, u)
-        sigref[] = u
-    end    
-    push!(input, input.value)  
+        if isa(sigref, Base.RefArray)
+            sigref.x[:] = u
+        else
+            sigref[] = u
+        end
+    end
+    push!(input, input.value)
     signal
 end
 
@@ -256,8 +264,12 @@ You can optionally specify a different initial value.
 function previous(input::Signal, default=value(input))
     past = Ref(default)
     map(input) do u
-        res = past[]
-        past[] = u
+        res = deepcopy(past.x)
+        if isa(past, Base.RefArray)
+            past.x[:] = u
+        else
+            past[] = u
+        end
         res
     end
 end
@@ -276,7 +288,7 @@ end
 """
 $(SIGNATURES)
 
-For compatibility with Reactive. 
+For compatibility with Reactive.
 It just returns the original Signal because this isn't needed with direct `push!` updates.
 """
 function preserve(x::Signal)

--- a/src/ReactiveBasics.jl
+++ b/src/ReactiveBasics.jl
@@ -2,9 +2,9 @@ module ReactiveBasics
 
 using DocStringExtensions
 
-export Signal, value, foldp, subscribe!, flatmap, flatten, bind!, droprepeats, previous, sampleon, preserve
+export Signal, value, foldp, subscribe!, flatmap, flatten, bind!, droprepeats, previous, sampleon, preserve, filterwhen
 
-# This API mainly follows that of Reactive.jl. 
+# This API mainly follows that of Reactive.jl.
 
 # The algorithms for were derived from the Swift Interstellar package
 # https://github.com/JensRavens/Interstellar/blob/master/Sources/Signal.swift
@@ -17,7 +17,7 @@ A `Signal` is value that will contain a value in the future.
 The value of the Signal can change at any time.
 
 Use `map` to derive new Signals, `subscribe!` to subscribe to updates of a Signal,
-and `push!` to update the current value of a Signal. 
+and `push!` to update the current value of a Signal.
 `value` returns the current value of a Signal.
 
 ```julia
@@ -87,7 +87,7 @@ end
 """
 $(SIGNATURES)
 
-Transform the Signal into another Signal using a function. It's like `map`, 
+Transform the Signal into another Signal using a function. It's like `map`,
 but it's meant for functions that return `Signal`s.
 """
 function flatmap(f, input::Signal)
@@ -98,7 +98,7 @@ function flatmap(f, input::Signal)
         subscribe!(innersig) do v
             push!(signal, v)
         end
-    end      
+    end
     signal
 end
 
@@ -125,7 +125,7 @@ end
 """
 $(SIGNATURES)
 
-Unsubscribe to the changes of this Signal. 
+Unsubscribe to the changes of this Signal.
 """
 function unsubscribe!(f, u::Signal)
     u.callbacks = filter(a -> a != f, u.callbacks)
@@ -137,7 +137,7 @@ $(SIGNATURES)
 
 Zip (combine) Signals into the current Signal. The value of the Signal is a
 Tuple of the values of the contained Signals.
-    
+
     signal = zip(Signal("Hello"), Signal("World"))
     value(signal)    # ("Hello", "World")
 """
@@ -163,7 +163,7 @@ end
 $(SIGNATURES)
 
 Fold/map over past values. The first argument to the function `f`
-is an accumulated value that the function can operate over, and the 
+is an accumulated value that the function can operate over, and the
 second is the current value coming in. `v0` is the initial value of
 the accumulated value.
 
@@ -190,6 +190,19 @@ end
 """
 $(SIGNATURES)
 
+Keep updates to `input` only when `switch` is true.
+If switch is false initially, the specified default value is used.
+"""
+function filterwhen{T}(predicate::Signal{Bool}, default::T, u::Signal{T})
+    signal = Signal(predicate.value ? u.value : default)
+    subscribe!(result -> predicate.value && push!(signal, result), u)
+    subscribe!(v -> v && push!(signal, u.value), predicate)
+    signal
+end
+
+"""
+$(SIGNATURES)
+
 An asynchronous version of `map` that returns a Signal that is updated after `f` operates asynchronously.
 The initial value of the returned Signal (the `init` arg) must be supplied.
 """
@@ -205,7 +218,7 @@ end
 $(SIGNATURES)
 
 Flatten a Signal of Signals into a Signal which holds the
-value of the current Signal. 
+value of the current Signal.
 """
 function flatten(input::Signal)
     sigref = Ref(input.value)
@@ -217,8 +230,8 @@ function flatten(input::Signal)
         unsubscribe!(updater, sigref[])
         subscribe!(updater, u)
         sigref[] = u
-    end    
-    push!(input, input.value)  
+    end
+    push!(input, input.value)
     signal
 end
 
@@ -276,7 +289,7 @@ end
 """
 $(SIGNATURES)
 
-For compatibility with Reactive. 
+For compatibility with Reactive.
 It just returns the original Signal because this isn't needed with direct `push!` updates.
 """
 function preserve(x::Signal)

--- a/src/ReactiveBasics.jl
+++ b/src/ReactiveBasics.jl
@@ -186,7 +186,7 @@ Merge Signals into the current Signal. The value of the Signal is that from
 the most recent update.
 """
 function Base.merge(u::Signal, us::Signal...)
-    signal = Signal(u.value)
+    signal = Signal(typejoin(map(x -> typeof(value(x)), (u, us...))...), u.value)
     for v in (u, us...)
         subscribe!(x -> push!(signal, x), v)
     end

--- a/src/ReactiveBasics.jl
+++ b/src/ReactiveBasics.jl
@@ -2,7 +2,7 @@ module ReactiveBasics
 
 using DocStringExtensions
 
-export Signal, value, foldp, subscribe!, unsubscribe!, flatmap, flatten, bind!, droprepeats, previous, 
+export Signal, value, foldp, subscribe!, unsubscribe!, flatmap, flatten, bind!, droprepeats, previous,
        sampleon, preserve, filterwhen, zipmap
 
 # This API mainly follows that of Reactive.jl.
@@ -42,6 +42,8 @@ type Signal{T}
 end
 
 Signal(val) = Signal(val, Function[])
+
+Signal{T}(::Type{T}, val) = Signal{T}(val, Function[])
 
 """
 $(SIGNATURES)

--- a/src/ReactiveBasics.jl
+++ b/src/ReactiveBasics.jl
@@ -182,8 +182,8 @@ Tuple of the values of the contained Signals.
 """
 function Base.zip(u::Signal, us::Signal...)
     signals = (u,us...)
-    signal = Signal(Tuple{map(u -> eltype(typeof(u)), signals)...}, map(value, signals))
-    pasts = collect(map(u -> Array{eltype(typeof(u)), 1}(0), signals))
+    signal = Signal(Tuple{map(eltype, signals)...}, map(value, signals))
+    pasts = collect(map(u -> Array{eltype(u), 1}(0), signals))
     for i in 1:length(signals)
         subscribe!(signals[i]) do u
             push!(pasts[i], u)
@@ -204,7 +204,7 @@ Merge Signals into the current Signal. The value of the Signal is that from
 the most recent update.
 """
 function Base.merge(u::Signal, us::Signal...)
-    signal = Signal(typejoin(map(x -> eltype(typeof(x)), (u, us...))...), u.value)
+    signal = Signal(typejoin(map(eltype, (u, us...))...), u.value)
     for v in (u, us...)
         subscribe!(x -> push!(signal, x), v)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -116,6 +116,14 @@ facts("Basic checks") do
 
         e = zip(d, b, a, Signal(3))
         @fact value(e) --> (value(d), value(b), value(a), 3)
+
+        as = Signal(Action{Int64}, Update(1))
+        bs = Signal(Reset(2))
+        cs = zip(as, bs)
+        @fact typeof(cs) --> Signal{Tuple{Action{Int64}, Reset{Int64}}}
+
+        push!(as, Reset(3))
+        @fact typeof(cs) --> Signal{Tuple{Action{Int64}, Reset{Int64}}}
     end
 
     context("foldp") do

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,11 +3,11 @@ using FactCheck
 
 number() = round(Int, rand()*1000)
 
-abstract type Action{T} end
-struct Update{T} <: Action{T}
+abstract Action{T}
+type Update{T} <: Action{T}
     val::T
 end
-struct Reset{T} <: Action{T}
+type Reset{T} <: Action{T}
     val::T
 end
 
@@ -20,9 +20,9 @@ facts("Basic checks") do
 
     context("Signal") do
         as = Signal(Action, Update(1))
-        @fact value(as) --> Update(1)
+        @fact typeof(value(as)) --> Update{Int64}
         push!(as, Reset(1))
-        @fact value(as) --> Reset(1)
+        @fact typeof(value(as)) --> Reset{Int64}
     end
 
     context("map") do
@@ -81,6 +81,11 @@ facts("Basic checks") do
         # way updates are pushed.
         @fact value(e) --> value(a)
 
+        # Merge two different signal types
+        as = Signal(Update(1))
+        bs = Signal(Reset(2))
+        cs = merge(as, bs)
+        @fact typeof(value(cs)) --> Update{Int64}
     end
 
     context("zip") do

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -77,6 +77,12 @@ facts("Basic checks") do
         nums = [6,3,1]
         map(x -> push!(a, x), nums)
         @fact sum(nums) --> value(f)
+
+        x = Signal(ones(4,5))
+        y = foldp((b,a) -> b + a, ones(4,5) * 2, x)
+        @fact value(y) --> ones(4,5) * 3
+        push!(x, ones(4,5))
+        @fact value(y) --> ones(4,5) * 4
     end
 
     context("filter") do
@@ -223,6 +229,22 @@ facts("Basic checks") do
         push!(x, 3)
 
         @fact value(y) --> 2
+
+        x = Signal(zeros(2,3))
+        y = previous(x)
+        @fact value(y) --> zeros(2,3)
+
+        push!(x, ones(2,3))
+
+        @fact value(y) --> zeros(2,3)
+
+        push!(x, ones(2,3) * 2)
+
+        @fact value(y) --> ones(2,3)
+
+        push!(x, ones(2,3) * 3)
+
+        @fact value(y) --> ones(2,3) * 2
     end
    
     context("bind!") do

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,7 +36,7 @@ facts("Basic checks") do
         push!(b, number())
         @fact value(c) --> value(a) + value(b)
     end
-   
+
     context("merge") do
 
         ## Merge
@@ -47,7 +47,7 @@ facts("Basic checks") do
         @fact value(e) --> value(d)
 
         push!(a, number())
-        # Note that his works differently than Reactive.jl because of the 
+        # Note that his works differently than Reactive.jl because of the
         # way updates are pushed.
         @fact value(e) --> value(a)
 
@@ -62,7 +62,7 @@ facts("Basic checks") do
 
         push!(a, number())
         @fact value(e) --> (value(d), value(b), value(a))
-        
+
         e = zip(d, b, a, Signal(3))
         push!(a, number())
         @fact value(e) --> (value(d), value(b), value(a), 3)
@@ -94,6 +94,28 @@ facts("Basic checks") do
 
         push!(g, 3)
         @fact value(h) --> 3
+    end
+
+    context("filterwhen") do
+        # filterwhen
+        bs = Signal(false)
+        as = Signal(1)
+        cs = filterwhen(bs, 9, as)
+        @fact value(cs) --> 9
+
+        bs = Signal(true)
+        as = Signal(1)
+        cs = filterwhen(bs, 9, as)
+        @fact value(cs) --> 1
+
+        push!(as, 2)
+        @fact value(cs) --> 2
+        push!(bs, false)
+        @fact value(cs) --> 2
+        push!(as, 5)
+        @fact value(cs) --> 2
+        push!(bs, true)
+        @fact value(cs) --> 5
     end
 
     context("push! inside push!") do
@@ -151,7 +173,7 @@ facts("Basic checks") do
 
         @fact value(y) --> -2
     end
-    
+
     context("flatmap") do
 
         a = Signal(1)
@@ -224,7 +246,7 @@ facts("Basic checks") do
 
         @fact value(y) --> 2
     end
-   
+
     context("bind!") do
         x = Signal(1)
         y = Signal(2)
@@ -297,4 +319,3 @@ facts("Flatten") do
         @fact value(d) --> value(b)
     end
 end
-

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,12 +3,27 @@ using FactCheck
 
 number() = round(Int, rand()*1000)
 
+abstract type Action{T} end
+struct Update{T} <: Action{T}
+    val::T
+end
+struct Reset{T} <: Action{T}
+    val::T
+end
+
 ## Basics
 
 facts("Basic checks") do
 
     a = Signal(number())
     b = map(x -> x*x, a)
+
+    context("Signal") do
+        as = Signal(Action, Update(1))
+        @fact value(as) --> Update(1)
+        push!(as, Reset(1))
+        @fact value(as) --> Reset(1)
+    end
 
     context("map") do
 
@@ -99,11 +114,7 @@ facts("Basic checks") do
         ## foldp over time
         push!(a, 0)
         f = foldp(+, 0, a)
-<<<<<<< HEAD
         nums = rand(Int, 100)
-=======
-        nums = round.(Int, rand(100)*1000)
->>>>>>> c355bd628871a00d8f09037788be46bc2e3f5508
         nums = [6,3,1]
         map(x -> push!(a, x), nums)
         @fact sum(nums) --> value(f)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,7 +36,7 @@ facts("Basic checks") do
         push!(b, number())
         @fact value(c) --> value(a) + value(b)
     end
-   
+
     context("merge") do
 
         ## Merge
@@ -47,7 +47,7 @@ facts("Basic checks") do
         @fact value(e) --> value(d)
 
         push!(a, number())
-        # Note that his works differently than Reactive.jl because of the 
+        # Note that his works differently than Reactive.jl because of the
         # way updates are pushed.
         @fact value(e) --> value(a)
 
@@ -57,14 +57,25 @@ facts("Basic checks") do
 
         ## zip
         d = Signal(number())
+        b = Signal(number())
+        a = Signal(number())
         e = zip(d, b, a)
         @fact value(e) --> (value(d), value(b), value(a))
 
-        push!(a, number())
-        @fact value(e) --> (value(d), value(b), value(a))
-        
+        d = Signal(1)
+        b = Signal(2)
+        a = Signal(3)
+        e = zip(d, b, a)
+        @fact value(e) --> (1,2,3)
+
+        push!(a, 6)
+        @fact value(e) --> (1,2,3)
+        push!(d, 4)
+        @fact value(e) --> (1,2,3)
+        push!(b, 5)
+        @fact value(e) --> (4,5,6)
+
         e = zip(d, b, a, Signal(3))
-        push!(a, number())
         @fact value(e) --> (value(d), value(b), value(a), 3)
     end
 
@@ -73,7 +84,7 @@ facts("Basic checks") do
         ## foldp over time
         push!(a, 0)
         f = foldp(+, 0, a)
-        nums = round(Int, rand(100)*1000)
+        nums = round.(Int, rand(100)*1000)
         nums = [6,3,1]
         map(x -> push!(a, x), nums)
         @fact sum(nums) --> value(f)
@@ -151,7 +162,7 @@ facts("Basic checks") do
 
         @fact value(y) --> -2
     end
-    
+
     context("flatmap") do
 
         a = Signal(1)
@@ -224,7 +235,7 @@ facts("Basic checks") do
 
         @fact value(y) --> 2
     end
-   
+
     context("bind!") do
         x = Signal(1)
         y = Signal(2)
@@ -297,4 +308,3 @@ facts("Flatten") do
         @fact value(d) --> value(b)
     end
 end
-

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -88,6 +88,12 @@ facts("Basic checks") do
         nums = [6,3,1]
         map(x -> push!(a, x), nums)
         @fact sum(nums) --> value(f)
+
+        x = Signal(ones(4,5))
+        y = foldp((b,a) -> b + a, ones(4,5) * 2, x)
+        @fact value(y) --> ones(4,5) * 3
+        push!(x, ones(4,5))
+        @fact value(y) --> ones(4,5) * 4
     end
 
     context("filter") do
@@ -234,6 +240,22 @@ facts("Basic checks") do
         push!(x, 3)
 
         @fact value(y) --> 2
+
+        x = Signal(zeros(2,3))
+        y = previous(x)
+        @fact value(y) --> zeros(2,3)
+
+        push!(x, ones(2,3))
+
+        @fact value(y) --> zeros(2,3)
+
+        push!(x, ones(2,3) * 2)
+
+        @fact value(y) --> ones(2,3)
+
+        push!(x, ones(2,3) * 3)
+
+        @fact value(y) --> ones(2,3) * 2
     end
 
     context("bind!") do

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -50,6 +50,10 @@ facts("Basic checks") do
 
         push!(b, number())
         @fact value(c) --> value(a) + value(b)
+
+        as = Signal(0)
+        bs = map(Update, as, typ = Action{Int64})
+        @fact typeof(bs) --> Signal{Action{Int64}}
     end
 
     context("zipmap") do


### PR DESCRIPTION
Unfortunately, if you want to reset the accumulator, the last pull request only works, if `foldp` is directly called after merging the two different signals (update and reset).
Since `merge` gets two different types (e.g. Update and Reset) it will look for their parent type and use that as the output type (e.g. Action). However, if you have to do a `map` before folding the result, the output will be either Update or Reset, since map is not "type-stable". But to reset an accumulator the given type for `foldp` must be Action.
Reactive.jl provides a "typ" parameter where you can define the output type. This feature is also provided with this pull request. Again this feels a little bit kludgy.
Another approach would be to define a "type-stable" map like so:

```julia
function smap{T}(f, u::Signal{T})
    signal = Signal(T, f(u.value))
    subscribe!(x -> push!(signal, f(x)), u)
    signal
end
```
meaning "stable" - map instead of

```julia
function Base.map(f, u::Signal; init = f(u.value), typ = typeof(init))
    signal = Signal(typ, init)
    subscribe!(x -> push!(signal, f(x)), u)
    signal
end
```
But with this approach, we have to implement two functions for every "type-unstable" function

Here is an example of the current behavior:

```julia
using ReactiveBasics
abstract type Action{T} end
struct Update{T} <: Action{T}
    val::T
end
struct Reset{T} <: Action{T}
    val::T
end
as = Signal(Update(1))
bs = Signal(Reset(2))
ms = merge(as, bs)
println(typeof(ms))
cs = map(x -> x, ms)
println(typeof(cs))
```
Output:

```
ReactiveBasics.Signal{Action{Int64}}
ReactiveBasics.Signal{Update{Int64}}
```
I need the last one to be Action as well