### PR TITLE
Added an optional max_buffer_size parameter to zip and optional initial parameter to bind!

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
 julia 0.5
 DocStringExtensions
+DataStructures

--- a/src/ReactiveBasics.jl
+++ b/src/ReactiveBasics.jl
@@ -298,7 +298,7 @@ ice-versa.
 If `initial` is set to true, `a` is updated immediately and, if `twoway` is true, `b`
 is updated immediately as well.
 """
-function bind!(a::Signal, b::Signal; twoway = true, initial = true)
+function bind!(a::Signal, b::Signal, twoway = true; initial = true)
     if initial
         push!(a, b.value)
         if twoway

--- a/src/ReactiveBasics.jl
+++ b/src/ReactiveBasics.jl
@@ -4,7 +4,7 @@ using DocStringExtensions
 
 export Signal, value, foldp, subscribe!, flatmap, flatten, bind!, droprepeats, previous, sampleon, preserve
 
-# This API mainly follows that of Reactive.jl. 
+# This API mainly follows that of Reactive.jl.
 
 # The algorithms for were derived from the Swift Interstellar package
 # https://github.com/JensRavens/Interstellar/blob/master/Sources/Signal.swift
@@ -17,7 +17,7 @@ A `Signal` is value that will contain a value in the future.
 The value of the Signal can change at any time.
 
 Use `map` to derive new Signals, `subscribe!` to subscribe to updates of a Signal,
-and `push!` to update the current value of a Signal. 
+and `push!` to update the current value of a Signal.
 `value` returns the current value of a Signal.
 
 ```julia
@@ -87,7 +87,7 @@ end
 """
 $(SIGNATURES)
 
-Transform the Signal into another Signal using a function. It's like `map`, 
+Transform the Signal into another Signal using a function. It's like `map`,
 but it's meant for functions that return `Signal`s.
 """
 function flatmap(f, input::Signal)
@@ -98,7 +98,7 @@ function flatmap(f, input::Signal)
         subscribe!(innersig) do v
             push!(signal, v)
         end
-    end      
+    end
     signal
 end
 
@@ -125,7 +125,7 @@ end
 """
 $(SIGNATURES)
 
-Unsubscribe to the changes of this Signal. 
+Unsubscribe to the changes of this Signal.
 """
 function unsubscribe!(f, u::Signal)
     u.callbacks = filter(a -> a != f, u.callbacks)
@@ -137,7 +137,7 @@ $(SIGNATURES)
 
 Zip (combine) Signals into the current Signal. The value of the Signal is a
 Tuple of the values of the contained Signals.
-    
+
     signal = zip(Signal("Hello"), Signal("World"))
     value(signal)    # ("Hello", "World")
 """
@@ -163,7 +163,7 @@ end
 $(SIGNATURES)
 
 Fold/map over past values. The first argument to the function `f`
-is an accumulated value that the function can operate over, and the 
+is an accumulated value that the function can operate over, and the
 second is the current value coming in. `v0` is the initial value of
 the accumulated value.
 
@@ -175,7 +175,11 @@ the accumulated value.
 """
 function foldp(f, v0, us::Signal...)
     v0r = Ref(v0)
-    map((x...) -> v0r[] = f(v0r[], x...), us...)
+    if isa(v0r, Base.RefArray)
+        map((x...) -> v0r.x[:] = f(v0r.x, x...), us...)
+    else
+        map((x...) -> v0r[] = f(v0r.x, x...), us...)
+    end
 end
 
 """
@@ -205,7 +209,7 @@ end
 $(SIGNATURES)
 
 Flatten a Signal of Signals into a Signal which holds the
-value of the current Signal. 
+value of the current Signal.
 """
 function flatten(input::Signal)
     sigref = Ref(input.value)
@@ -214,11 +218,15 @@ function flatten(input::Signal)
     subscribe!(updater, input.value)
     subscribe!(input) do u
         push!(signal, u.value)
-        unsubscribe!(updater, sigref[])
+        unsubscribe!(updater, sigref.x)
         subscribe!(updater, u)
-        sigref[] = u
-    end    
-    push!(input, input.value)  
+        if isa(sigref, Base.RefArray)
+            sigref.x[:] = u
+        else
+            sigref[] = u
+        end
+    end
+    push!(input, input.value)
     signal
 end
 
@@ -256,8 +264,12 @@ You can optionally specify a different initial value.
 function previous(input::Signal, default=value(input))
     past = Ref(default)
     map(input) do u
-        res = past[]
-        past[] = u
+        res = deepcopy(past.x)
+        if isa(past, Base.RefArray)
+            past.x[:] = u
+        else
+            past[] = u
+        end
         res
     end
 end
@@ -276,7 +288,7 @@ end
 """
 $(SIGNATURES)
 
-For compatibility with Reactive. 
+For compatibility with Reactive.
 It just returns the original Signal because this isn't needed with direct `push!` updates.
 """
 function preserve(x::Signal)

--- a/src/ReactiveBasics.jl
+++ b/src/ReactiveBasics.jl
@@ -134,8 +134,8 @@ be set via `typ`. Otherwise it defaults to the type of the initial value.
     cs = zipmap((a,b) -> a + b, as, bs) # This calculation is done once for
                                         # every change in `as`
 """
-function zipmap(f, u::Signal, us::Signal...; init = f(zip(u, us...).value...), typ = typeof(init))
-    zipped_signal = zip(u, us...)
+function zipmap(f, u::Signal, us::Signal...; init = f(zip(u, us...).value...), typ = typeof(init), max_buffer_size = 0)
+    zipped_signal = max_buffer_size == 0 ? zip(u, us...) : zip(max_buffer_size, u, us...)
     signal = Signal(typ, init)
     subscribe!(x -> push!(signal, f(x...)), zipped_signal)
     signal
@@ -180,21 +180,42 @@ Tuple of the values of the contained Signals.
     signal = zip(Signal("Hello"), Signal("World"))
     value(signal)    # ("Hello", "World")
 """
-function Base.zip(u::Signal, us::Signal...)
+function Base.zip(u::Signal, us::Signal...; max_buffer_size = 0)
     signals = (u,us...)
     signal = Signal(Tuple{map(eltype, signals)...}, map(value, signals))
-    pasts = collect(map(u -> Array{eltype(u), 1}(0), signals))
+    pasts = map(u -> Array{eltype(u), 1}(max_buffer_size), signals)
+    max_buffer_size == 0 ? _zip!(signals, signal, pasts) : _zip!(signals, signal, pasts, max_buffer_size)
+    signal
+end
+
+function _zip!(signals, output, pasts)
     for i in 1:length(signals)
         subscribe!(signals[i]) do u
             push!(pasts[i], u)
-            not_empty_pasts = map(!isempty, pasts)
-            if all(not_empty_pasts)
-                zip_vals = map(shift!, pasts)
-                push!(signal, (zip_vals...))
+            if all(map(!isempty, pasts))
+                push!(output, map(shift!, pasts))
             end
         end
     end
-    signal
+end
+
+function _zip!(signals, output, pasts, max_buffer_size)
+    counters = zeros(Int64, length(signals))
+    start = 1
+    for i in 1:length(signals)
+        subscribe!(signals[i]) do u
+            if counters[i] >= max_buffer_size
+                error(@sprintf("Signal input %i reached the zipping buffer size of %i.", i, max_buffer_size))
+            end
+            pasts[i][mod(start - 1 + counters[i], max_buffer_size) + 1] = u
+            counters[i] += 1
+            if all(counters .> 0)
+                push!(output, map(u -> u[start], pasts))
+                start = mod(start, max_buffer_size) + 1
+                counters -= ones(counters)
+            end
+        end
+    end
 end
 
 """

--- a/src/ReactiveBasics.jl
+++ b/src/ReactiveBasics.jl
@@ -2,9 +2,9 @@ module ReactiveBasics
 
 using DocStringExtensions
 
-export Signal, value, foldp, subscribe!, flatmap, flatten, bind!, droprepeats, previous, sampleon, preserve
+export Signal, value, foldp, subscribe!, flatmap, flatten, bind!, droprepeats, previous, sampleon, preserve, filterwhen
 
-# This API mainly follows that of Reactive.jl. 
+# This API mainly follows that of Reactive.jl.
 
 # The algorithms for were derived from the Swift Interstellar package
 # https://github.com/JensRavens/Interstellar/blob/master/Sources/Signal.swift
@@ -17,7 +17,7 @@ A `Signal` is value that will contain a value in the future.
 The value of the Signal can change at any time.
 
 Use `map` to derive new Signals, `subscribe!` to subscribe to updates of a Signal,
-and `push!` to update the current value of a Signal. 
+and `push!` to update the current value of a Signal.
 `value` returns the current value of a Signal.
 
 ```julia
@@ -87,7 +87,7 @@ end
 """
 $(SIGNATURES)
 
-Transform the Signal into another Signal using a function. It's like `map`, 
+Transform the Signal into another Signal using a function. It's like `map`,
 but it's meant for functions that return `Signal`s.
 """
 function flatmap(f, input::Signal)
@@ -98,7 +98,7 @@ function flatmap(f, input::Signal)
         subscribe!(innersig) do v
             push!(signal, v)
         end
-    end      
+    end
     signal
 end
 
@@ -125,7 +125,7 @@ end
 """
 $(SIGNATURES)
 
-Unsubscribe to the changes of this Signal. 
+Unsubscribe to the changes of this Signal.
 """
 function unsubscribe!(f, u::Signal)
     u.callbacks = filter(a -> a != f, u.callbacks)
@@ -137,7 +137,7 @@ $(SIGNATURES)
 
 Zip (combine) Signals into the current Signal. The value of the Signal is a
 Tuple of the values of the contained Signals.
-    
+
     signal = zip(Signal("Hello"), Signal("World"))
     value(signal)    # ("Hello", "World")
 """
@@ -163,7 +163,7 @@ end
 $(SIGNATURES)
 
 Fold/map over past values. The first argument to the function `f`
-is an accumulated value that the function can operate over, and the 
+is an accumulated value that the function can operate over, and the
 second is the current value coming in. `v0` is the initial value of
 the accumulated value.
 
@@ -190,6 +190,19 @@ end
 """
 $(SIGNATURES)
 
+Keep updates to `input` only when `switch` is true.
+If switch is false initially, the specified default value is used.
+"""
+function filterwhen{T}(predicate::Signal{Bool}, default::T, u::Signal{T})
+    signal = Signal(predicate.value ? u.value : default)
+    subscribe!(result -> predicate.value && push!(signal, result), u)
+    subscribe!(v -> v && push!(signal, u.value), predicate)
+    signal
+end
+
+"""
+$(SIGNATURES)
+
 An asynchronous version of `map` that returns a Signal that is updated after `f` operates asynchronously.
 The initial value of the returned Signal (the `init` arg) must be supplied.
 """
@@ -205,7 +218,7 @@ end
 $(SIGNATURES)
 
 Flatten a Signal of Signals into a Signal which holds the
-value of the current Signal. 
+value of the current Signal.
 """
 function flatten(input::Signal)
     sigref = Ref(input.value)
@@ -217,8 +230,8 @@ function flatten(input::Signal)
         unsubscribe!(updater, sigref[])
         subscribe!(updater, u)
         sigref[] = u
-    end    
-    push!(input, input.value)  
+    end
+    push!(input, input.value)
     signal
 end
 
@@ -276,7 +289,7 @@ end
 """
 $(SIGNATURES)
 
-For compatibility with Reactive. 
+For compatibility with Reactive.
 It just returns the original Signal because this isn't needed with direct `push!` updates.
 """
 function preserve(x::Signal)

--- a/src/ReactiveBasics.jl
+++ b/src/ReactiveBasics.jl
@@ -135,7 +135,7 @@ be set via `typ`. Otherwise it defaults to the type of the initial value.
                                         # every change in `as`
 """
 function zipmap(f, u::Signal, us::Signal...; init = f(zip(u, us...).value...), typ = typeof(init), max_buffer_size = 0)
-    zipped_signal = max_buffer_size == 0 ? zip(u, us...) : zip(max_buffer_size, u, us...)
+    zipped_signal = zip(u, us..., max_buffer_size = max_buffer_size)
     signal = Signal(typ, init)
     subscribe!(x -> push!(signal, f(x...)), zipped_signal)
     signal

--- a/src/ReactiveBasics.jl
+++ b/src/ReactiveBasics.jl
@@ -293,12 +293,18 @@ end
 """
 $(SIGNATURES)
 
-For every update to `b` also update `a` with the same value and, if
-`twoway` is true, vice-versa.
-Initially update `a` with the value in `b`.
+For every update to `b` also update `a` with the same value and, if `twoway` is true,
+ice-versa.
+If `initial` is set to true, `a` is updated immediately and, if `twoway` is true, `b`
+is updated immediately as well.
 """
-function bind!(a::Signal, b::Signal, twoway=true)
-    push!(a, b.value)
+function bind!(a::Signal, b::Signal; twoway = true, initial = true)
+    if initial
+        push!(a, b.value)
+        if twoway
+            push!(b, a.value)
+        end
+    end
     if twoway
         subscribe!(u -> u != value(b) && push!(b, u), a)
     end

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,2 @@
 FactCheck
+DataStructures

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,2 +1,1 @@
 FactCheck
-DataStructures

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -131,11 +131,6 @@ facts("Basic checks") do
         ## foldp over time
         push!(a, 0)
         f = foldp(+, 0, a)
-<<<<<<< HEAD
-        nums = rand(Int, 100)
-=======
-        nums = round.(Int, rand(100)*1000)
->>>>>>> c355bd628871a00d8f09037788be46bc2e3f5508
         nums = [6,3,1]
         map(x -> push!(a, x), nums)
         @fact sum(nums) --> value(f)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -77,6 +77,12 @@ facts("Basic checks") do
         nums = [6,3,1]
         map(x -> push!(a, x), nums)
         @fact sum(nums) --> value(f)
+
+        x = Signal(ones(4,5))
+        y = foldp((b,a) -> b + a, ones(4,5) * 2, x)
+        @fact value(y) --> ones(4,5) * 3
+        push!(x, ones(4,5))
+        @fact value(y) --> ones(4,5) * 4
     end
 
     context("filter") do
@@ -223,6 +229,22 @@ facts("Basic checks") do
         push!(x, 3)
 
         @fact value(y) --> 2
+
+        x = Signal(zeros(2,3))
+        y = previous(x)
+        @fact value(y) --> zeros(2,3)
+
+        push!(x, ones(2,3))
+
+        @fact value(y) --> zeros(2,3)
+
+        push!(x, ones(2,3) * 2)
+
+        @fact value(y) --> ones(2,3)
+
+        push!(x, ones(2,3) * 3)
+
+        @fact value(y) --> ones(2,3) * 2
     end
    
     context("bind!") do

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -347,7 +347,7 @@ facts("Basic checks") do
         y = Signal(2)
         xx = map(u -> 2u, x)
         yy = map(u -> 3u, y)
-        bind!(x, y, twoway = false)
+        bind!(x, y, false)
         @fact value(y) --> value(x)
         @fact value(y) --> 2
         push!(x, 10)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,7 +36,7 @@ facts("Basic checks") do
         push!(b, number())
         @fact value(c) --> value(a) + value(b)
     end
-   
+
     context("merge") do
 
         ## Merge
@@ -47,7 +47,7 @@ facts("Basic checks") do
         @fact value(e) --> value(d)
 
         push!(a, number())
-        # Note that his works differently than Reactive.jl because of the 
+        # Note that his works differently than Reactive.jl because of the
         # way updates are pushed.
         @fact value(e) --> value(a)
 
@@ -62,7 +62,7 @@ facts("Basic checks") do
 
         push!(a, number())
         @fact value(e) --> (value(d), value(b), value(a))
-        
+
         e = zip(d, b, a, Signal(3))
         push!(a, number())
         @fact value(e) --> (value(d), value(b), value(a), 3)
@@ -94,6 +94,28 @@ facts("Basic checks") do
 
         push!(g, 3)
         @fact value(h) --> 3
+    end
+
+    context("filterwhen") do
+        # filterwhen
+        bs = Signal(false)
+        as = Signal(1)
+        cs = filterwhen(bs, 9, as)
+        @fact value(cs) --> 9
+
+        bs = Signal(true)
+        as = Signal(1)
+        cs = filterwhen(bs, 9, as)
+        @fact value(cs) --> 1
+
+        push!(as, 2)
+        @fact value(cs) --> 2
+        push!(bs, false)
+        @fact value(cs) --> 2
+        push!(as, 5)
+        @fact value(cs) --> 2
+        push!(bs, true)
+        @fact value(cs) --> 5
     end
 
     context("push! inside push!") do
@@ -151,7 +173,7 @@ facts("Basic checks") do
 
         @fact value(y) --> -2
     end
-    
+
     context("flatmap") do
 
         a = Signal(1)
@@ -224,7 +246,7 @@ facts("Basic checks") do
 
         @fact value(y) --> 2
     end
-   
+
     context("bind!") do
         x = Signal(1)
         y = Signal(2)
@@ -297,4 +319,3 @@ facts("Flatten") do
         @fact value(d) --> value(b)
     end
 end
-

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,7 +36,7 @@ facts("Basic checks") do
         push!(b, number())
         @fact value(c) --> value(a) + value(b)
     end
-   
+
     context("merge") do
 
         ## Merge
@@ -47,7 +47,7 @@ facts("Basic checks") do
         @fact value(e) --> value(d)
 
         push!(a, number())
-        # Note that his works differently than Reactive.jl because of the 
+        # Note that his works differently than Reactive.jl because of the
         # way updates are pushed.
         @fact value(e) --> value(a)
 
@@ -57,14 +57,25 @@ facts("Basic checks") do
 
         ## zip
         d = Signal(number())
+        b = Signal(number())
+        a = Signal(number())
         e = zip(d, b, a)
         @fact value(e) --> (value(d), value(b), value(a))
 
-        push!(a, number())
-        @fact value(e) --> (value(d), value(b), value(a))
-        
+        d = Signal(1)
+        b = Signal(2)
+        a = Signal(3)
+        e = zip(d, b, a)
+        @fact value(e) --> (1,2,3)
+
+        push!(a, 6)
+        @fact value(e) --> (1,2,3)
+        push!(d, 4)
+        @fact value(e) --> (1,2,3)
+        push!(b, 5)
+        @fact value(e) --> (4,5,6)
+
         e = zip(d, b, a, Signal(3))
-        push!(a, number())
         @fact value(e) --> (value(d), value(b), value(a), 3)
     end
 
@@ -73,7 +84,7 @@ facts("Basic checks") do
         ## foldp over time
         push!(a, 0)
         f = foldp(+, 0, a)
-        nums = round(Int, rand(100)*1000)
+        nums = round.(Int, rand(100)*1000)
         nums = [6,3,1]
         map(x -> push!(a, x), nums)
         @fact sum(nums) --> value(f)
@@ -151,7 +162,7 @@ facts("Basic checks") do
 
         @fact value(y) --> -2
     end
-    
+
     context("flatmap") do
 
         a = Signal(1)
@@ -224,7 +235,7 @@ facts("Basic checks") do
 
         @fact value(y) --> 2
     end
-   
+
     context("bind!") do
         x = Signal(1)
         y = Signal(2)
@@ -297,4 +308,3 @@ facts("Flatten") do
         @fact value(d) --> value(b)
     end
 end
-

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -347,12 +347,27 @@ facts("Basic checks") do
         y = Signal(2)
         xx = map(u -> 2u, x)
         yy = map(u -> 3u, y)
-        bind!(x, y, false)
+        bind!(x, y, twoway = false)
         @fact value(y) --> value(x)
         @fact value(y) --> 2
         push!(x, 10)
         @fact value(y) --> 2
         @fact value(x) --> 10
+        push!(y, 20)
+        @fact value(y) --> value(x)
+        @fact value(y) --> 20
+        @fact value(xx) --> 40
+
+        x = Signal(1)
+        y = Signal(2)
+        xx = map(u -> 2u, x)
+        yy = map(u -> 3u, y)
+        bind!(x, y, initial = false)
+        @fact value(x) --> 1
+        @fact value(y) --> 2
+        push!(x, 10)
+        @fact value(y) --> 10
+        @fact value(yy) --> 30
         push!(y, 20)
         @fact value(y) --> value(x)
         @fact value(y) --> 20

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -124,10 +124,47 @@ facts("Basic checks") do
 
         push!(as, Reset(3))
         @fact typeof(cs) --> Signal{Tuple{Action{Int64}, Reset{Int64}}}
+
+        d = Signal(1)
+        b = Signal(2)
+        a = Signal(3)
+        e = zip(d, b, a, max_buffer_size = 1)
+        @fact value(e) --> (1,2,3)
+        push!(a, 1)
+        @fact value(e) --> (1,2,3)
+        error = false
+        try
+            push!(a, 1)
+        catch
+            error = true
+        end
+        @fact error --> true
+        push!(b, 1)
+        push!(d, 2)
+        @fact value(e) --> (2, 1, 1)
+
+        d = Signal(1)
+        b = Signal(2)
+        a = Signal(3)
+        e = zip(d, b, a, max_buffer_size = 2)
+        @fact value(e) --> (1,2,3)
+        push!(a, 1)
+        push!(a, 2)
+        @fact value(e) --> (1,2,3)
+        error = false
+        try
+            push!(a, 1)
+        catch
+            error = true
+        end
+        @fact error --> true
+        push!(b, 1)
+        push!(d, 2)
+        @fact value(e) --> (2, 1, 1)
     end
 
     context("foldp") do
-
+        a = Signal(0)
         ## foldp over time
         push!(a, 0)
         f = foldp(+, 0, a)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -88,6 +88,12 @@ facts("Basic checks") do
         nums = [6,3,1]
         map(x -> push!(a, x), nums)
         @fact sum(nums) --> value(f)
+
+        x = Signal(ones(4,5))
+        y = foldp((b,a) -> b + a, ones(4,5) * 2, x)
+        @fact value(y) --> ones(4,5) * 3
+        push!(x, ones(4,5))
+        @fact value(y) --> ones(4,5) * 4
     end
 
     context("filter") do
@@ -234,6 +240,22 @@ facts("Basic checks") do
         push!(x, 3)
 
         @fact value(y) --> 2
+
+        x = Signal(zeros(2,3))
+        y = previous(x)
+        @fact value(y) --> zeros(2,3)
+
+        push!(x, ones(2,3))
+
+        @fact value(y) --> zeros(2,3)
+
+        push!(x, ones(2,3) * 2)
+
+        @fact value(y) --> ones(2,3)
+
+        push!(x, ones(2,3) * 3)
+
+        @fact value(y) --> ones(2,3) * 2
     end
 
     context("bind!") do


### PR DESCRIPTION
Sometimes the max number of updates on a signal is known before it is zipped. In this case the zip buffer size can be predefined. This avoids the call to push! and shift! multiple times on the buffer array. Moreover, it makes me more confident to set a maximum buffer size to be sure that there is no misalignment in the code. So one can be sure that the buffer size is not continuously increasing. For now it throws an error if the buffer size is exceeded. Do you suggest another approach?

Also I set an optional initial value on bind!

