### PR TITLE
Implemented reactive skip

### DIFF
--- a/src/ReactiveBasics.jl
+++ b/src/ReactiveBasics.jl
@@ -2,8 +2,8 @@ module ReactiveBasics
 
 using DocStringExtensions, DataStructures
 
-export Signal, value, foldp, subscribe!, unsubscribe!, flatmap, flatten, bind!, droprepeats, previous,
-       sampleon, preserve, filterwhen, zipmap
+export Signal, value, foldp, subscribe!, unsubscribe!, flatmap, flatten, bind!,
+       droprepeats, skip, previous, sampleon, preserve, filterwhen, zipmap
 
 # This API mainly follows that of Reactive.jl.
 
@@ -318,6 +318,21 @@ as the previous value of the Signal.
 function droprepeats{T}(input::Signal{T})
     result = Signal(T, value(input))
     subscribe!(u -> u != value(result) && push!(result, u), input)
+    result
+end
+
+"""
+$(SIGNATURES)
+
+Continuously skip a predefined number of updates to `input`
+"""
+function Base.skip{T}(num::Int, input::Signal{T})
+    result = Signal(T, value(input))
+    counter = 1
+    subscribe!(input) do u
+        mod(counter, num + 1) == 0 && push!(result, u)
+        counter = mod(counter, num + 1) + 1
+    end
     result
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -329,6 +329,38 @@ facts("Basic checks") do
         @fact value(n) --> 6
     end
 
+    context("skip") do
+        x = Signal(0)
+        y = skip(2, x)
+        count = foldp((x, y) -> x+1, -1, y)
+        @fact value(y) --> 0
+        @fact value(count) --> 0
+
+        push!(x, 1)
+        @fact value(y) --> 0
+        @fact value(count) --> 0
+
+        push!(x, 2)
+        @fact value(y) --> 0
+        @fact value(count) --> 0
+
+        push!(x, 3)
+        @fact value(y) --> 3
+        @fact value(count) --> 1
+
+        push!(x, 4)
+        @fact value(y) --> 3
+        @fact value(count) --> 1
+
+        push!(x, 5)
+        @fact value(y) --> 3
+        @fact value(count) --> 1
+
+        push!(x, 6)
+        @fact value(y) --> 6
+        @fact value(count) --> 2
+    end
+
     context("previous") do
         x = Signal(0)
         y = previous(x)


### PR DESCRIPTION
I have implemented a reactive skip.
It comes especially in handy in situations with merge and a diamond shape of structure:
```
as = Signal(1)
bs = map(x->x+1, as)
cs = skip(1, merge(as,bs))
```
`cs` will only "fire" once everytime `as` is updated